### PR TITLE
Removed the mandatory service token flow

### DIFF
--- a/js/src/bridge/engine.js
+++ b/js/src/bridge/engine.js
@@ -7,10 +7,6 @@ export function createJSONFrom(action, target, obj) {
 
     const serviceToken = getServiceToken();
 
-    if (!serviceToken || getServiceToken().tokenId.trim() === "") {
-        throw new Error("You need to set the service token before using any methods from the SDK !");
-    }
-
     let json = {};
     json.action = action;
     json.target = target;
@@ -56,8 +52,8 @@ export function createJSONFrom(action, target, obj) {
                     if (obj.error) {
                         window[errorCallback] = obj.error;
                     } else {
-                        window[errorCallback] = function () {
-
+                        window[errorCallback] = function (err) {
+                            console.error(err);
                         };
                     }
                 }

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -231,13 +231,12 @@ export function openProfile(obj) {
     sendFromJS(JSON.stringify(jsonObj));
 }
 
-export function openImage(url) {
-    if (!url) {
+export function openImage(obj) {
+    if (!obj || (obj && !obj.url)) {
         throw new Error("You need to set an image url to call this method !");
     }
-    let obj = {};
     obj.data = {
-        imageUrl: url
+        imageUrl: obj.url
     };
     const jsonObj = createJSONFrom("ui", "showImage", obj);
     sendFromJS(JSON.stringify(jsonObj));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workwell",
-  "version": "2.0.25",
+  "version": "2.0.26",
   "description": "Workwell JS is the SDK to communicate between a web-application and the Workwell mobile application",
   "main": "dist/js/workwell.js",
   "scripts": {


### PR DESCRIPTION
- Removed the mandatory service token flow (they can still use it but now the sdk won't block the user if he forgets to put a serviceToken)